### PR TITLE
Fix PyPi deployment issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ You can also zip your plots once plotting is complete for easier downloading.
 
 There's also a command line interface.
 
-```commandline
+```bash
 $ energyplus_diffs --help
 Usage: eplus-diff [OPTIONS] BASELINE_CSV MODIFIED_CSV OUTPUT_DIR
 

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,6 @@ from energyplus_diffs import VERSION
 readme_file = Path(__file__).parent.resolve() / 'README.md'
 readme_contents = readme_file.read_text()
 
-license_file = Path(__file__).parent.resolve() / 'LICENSE'
-license_contents = license_file.read_text()
-
 setup(
     name="energyplus_diff_analysis",
     version=VERSION,
@@ -25,7 +22,7 @@ setup(
     author='Matt Mitchell',
     author_email='mitchute@gmail.com',
     url='https://github.com/mitchute/energyplus-diff-analysis',
-    license=license_contents,
+    license="MIT",
     entry_points={
         'console_scripts': ['energyplus_diffs=energyplus_diffs.cli:cli']
     }


### PR DESCRIPTION
I was half expecting PyPi to complain about the new package name, but instead, the preprocessor complained about the contents of the long_description which is used on the package page on PyPi.  I was seeing one small "error" in the readme, so I fixed that...let's see.