### PR TITLE
Revert pinned dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,13 @@
-click>=8.1.3
-matplotlib>=3.7.0
-pandas>=1.5.3
+click
+matplotlib
+pandas
 
 # docs
-sphinx>=6.1.3
-sphinx-rtd-theme>=1.2.0
+sphinx
+sphinx-rtd-theme
 
 # tests
-coverage>=7.2.1
-flake8>=6.0.0
-nose>=1.3.7
+# coveralls is purposfully set at an older version to be compatible with coveralls.io
+coveralls==2.2.0
+flake8
+nose

--- a/setup.py
+++ b/setup.py
@@ -12,17 +12,13 @@ setup(
     version=VERSION,
     packages=['energyplus_diffs'],
     description="A tool used for plotting and comparing separate EnergyPlus output CSV files.",
-    install_requires=[
-        'click>=8.1.3',
-        'matplotlib>=3.7.0',
-        'pandas>=1.5.3'
-    ],
+    install_requires=['click', 'matplotlib', 'pandas'],
     long_description=readme_contents,
     long_description_content_type='text/markdown',
     author='Matt Mitchell',
     author_email='mitchute@gmail.com',
     url='https://github.com/mitchute/energyplus-diff-analysis',
-    license="MIT",
+    license='MIT License',
     entry_points={
         'console_scripts': ['energyplus_diffs=energyplus_diffs.cli:cli']
     }


### PR DESCRIPTION
This should be a temporary thing.  It would be good to pin our dependencies, but I think we need to be a little more generous with the versions.  I think what would be really best would be to look at exactly which functions we are using in the dependencies, and check the documentation of each.  See when the function was added and pin to that as our minimum.  It's a bit of work, but shouldn't be hard and only a matter of minutes not hours.  I'll try to tackle this later.

For now, reverting this just assumes any version of the library would work, which is probably reasonable.